### PR TITLE
Consider status code 101 as success

### DIFF
--- a/src/Drivers/RestDriver.php
+++ b/src/Drivers/RestDriver.php
@@ -62,7 +62,7 @@ class RestDriver implements DriverInterface
     {
         $result = $this->restCall('PaymentVerification.json', $inputs);
 
-        if ($result['Status'] == 100) {
+        if ($result['Status'] == 100 || $result['Status'] == 101) {
             return ['Status' => 'success', 'RefID' => $result['RefID']];
         } else {
             return ['Status' => 'error', 'error' => $result['Status']];


### PR DESCRIPTION
I think status code 101 should not be considered as error code because it is a successful verification but it is called another time.
This note could be used for other similar verification functions.